### PR TITLE
SF3 compat : Read file in YAML::parse

### DIFF
--- a/Loader/ServerLoader.php
+++ b/Loader/ServerLoader.php
@@ -29,7 +29,7 @@ class ServerLoader implements LoaderInterface
         }
 
         if (is_string($filename)) {
-            $configs = Yaml::parse($filename);
+            $configs = Yaml::parse(file_get_contents($filename));
         } elseif (is_array($filename)) {
             $configs = $filename;
         } else {


### PR DESCRIPTION
Doc here :
http://symfony.com/doc/current/components/yaml.html 
"Passing a filename is deprecated in Symfony 2.2, and was removed in Symfony 3.0."